### PR TITLE
Update overview page heading to General Knowledge

### DIFF
--- a/app/overview/page.tsx
+++ b/app/overview/page.tsx
@@ -3,13 +3,13 @@ import Sidebar from '../../components/Sidebar';
 import ContentSection from '../../components/ContentSection';
 import { pages } from '../../content/pages';
 
-export const metadata = { title: 'Overview | Leiomyosarcoma Portal' };
+export const metadata = { title: 'General Knowledge | Leiomyosarcoma Portal' };
 
 export default function Page() {
   const nav = pages.map(p => ({ href: `/${p.slug}`, label: p.title }));
   return (
     <div>
-      <Hero title="Overview" subtitle="Leiomyosarcoma (LMS) is a rare cancer that arises from smooth muscle cells." />
+      <Hero title="General Knowledge" subtitle="Leiomyosarcoma (LMS) is a rare cancer that arises from smooth muscle cells." />
       <div className="layout">
         <Sidebar items={nav} />
         <article className="content">

--- a/content/pages.ts
+++ b/content/pages.ts
@@ -1,7 +1,7 @@
 export type PageDef = { slug: string; title: string; summary: string };
 
 export const pages: PageDef[] = [
-  { slug: 'overview', title: 'Overview', summary: 'What leiomyosarcoma is and who it affects.' },
+  { slug: 'overview', title: 'General Knowledge', summary: 'What leiomyosarcoma is and who it affects.' },
   { slug: 'symptoms', title: 'Symptoms', summary: 'Common signs and when to see a doctor.' },
   { slug: 'diagnosis', title: 'Diagnosis', summary: 'Imaging, biopsy, and pathology basics.' },
   { slug: 'staging', title: 'Staging', summary: 'How stage and grade are determined.' },


### PR DESCRIPTION
## Summary
- rename the overview page metadata and hero heading to "General Knowledge"
- update the navigation configuration to use the new "General Knowledge" label

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e31f04f88083308ec064a190f16f3d